### PR TITLE
Centralize dependencies in a dedicated module

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,5 @@
+ext {
+    grpcVersion= "1.46.0"
+    protobufVersion= "3.20.1"
+    protocVersion= "3.20.1"
+}

--- a/dependencies/build.gradle
+++ b/dependencies/build.gradle
@@ -1,0 +1,22 @@
+plugins {
+    id "java-platform"
+}
+
+dependencies {
+    constraints {
+        api("commons-cli:commons-cli:1.5.0")
+        api("io.grpc:grpc-protobuf:${grpcVersion}")
+        api("io.grpc:grpc-stub:${grpcVersion}")
+        api("io.grpc:grpc-services:${grpcVersion}")
+        api("io.grpc:grpc-api:${grpcVersion}")
+        api("io.grpc:grpc-netty-shaded:${grpcVersion}")
+        api("me.dinowernli:java-grpc-prometheus:0.5.0")
+        api("io.prometheus:simpleclient_httpserver:0.15.0")
+        api("junit:junit:4.11")
+        api('org.assertj:assertj-core:3.21.0')
+        api('javax.annotation:javax.annotation-api:1.3.2')
+        api("junit:junit:4.11")
+        api('org.assertj:assertj-core:3.21.0')
+        api("com.google.protobuf:protoc:${protocVersion}")
+    }
+}

--- a/dependencies/build.gradle
+++ b/dependencies/build.gradle
@@ -13,9 +13,7 @@ dependencies {
         api("me.dinowernli:java-grpc-prometheus:0.5.0")
         api("io.prometheus:simpleclient_httpserver:0.15.0")
         api("junit:junit:4.11")
-        api('org.assertj:assertj-core:3.21.0')
         api('javax.annotation:javax.annotation-api:1.3.2')
-        api("junit:junit:4.11")
         api('org.assertj:assertj-core:3.21.0')
         api("com.google.protobuf:protoc:${protocVersion}")
     }

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -25,7 +25,8 @@ repositories {
 
 dependencies {
     // gRPC Utils project
-    implementation project(path: ':grpc-utils')
+    implementation platform(project(":dependencies"))
+    implementation project(':grpc-utils')
     implementation('javax.annotation:javax.annotation-api')
     testImplementation("junit:junit")
     testImplementation('org.assertj:assertj-core')

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -25,7 +25,6 @@ repositories {
 
 dependencies {
     // gRPC Utils project
-    api platform(project(":dependencies"))
     implementation project(path: ':grpc-utils')
     implementation('javax.annotation:javax.annotation-api')
     testImplementation("junit:junit")

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -5,14 +5,14 @@ buildscript {
         google()
     }
     dependencies {
-        classpath("com.google.protobuf:protobuf-gradle-plugin:${protobufGradle}")
+        classpath("com.google.protobuf:protobuf-gradle-plugin:${protobufGradlePluginVersion}")
     }
 }
 
 plugins {
     id "java"
     id "java-library"
-    id "com.google.protobuf" version "${protobufGradle}"
+    id "com.google.protobuf"
     id "idea"
     id "application"
     id "distribution"
@@ -25,7 +25,7 @@ repositories {
 
 dependencies {
     // gRPC Utils project
-    api platform(project(path: ":dependencies"))
+    api platform(project(":dependencies"))
     implementation project(path: ':grpc-utils')
     implementation('javax.annotation:javax.annotation-api')
     testImplementation("junit:junit")

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -5,21 +5,19 @@ buildscript {
         google()
     }
     dependencies {
-        classpath("com.google.protobuf:protobuf-gradle-plugin:0.8.18")
+        classpath("com.google.protobuf:protobuf-gradle-plugin:${protobufGradle}")
     }
 }
 
 plugins {
     id "java"
-    id "com.google.protobuf" version "0.8.18"
+    id "java-library"
+    id "com.google.protobuf" version "${protobufGradle}"
     id "idea"
     id "application"
     id "distribution"
 }
 
-def grpcVersion = "1.46.0"
-def protobufVersion = "3.20.1"
-def protocVersion = protobufVersion
 
 repositories {
     mavenCentral()
@@ -27,10 +25,11 @@ repositories {
 
 dependencies {
     // gRPC Utils project
+    api platform(project(path: ":dependencies"))
     implementation project(path: ':grpc-utils')
-    implementation('javax.annotation:javax.annotation-api:1.3.2')
-    testImplementation("junit:junit:4.11")
-    testImplementation('org.assertj:assertj-core:3.21.0')
+    implementation('javax.annotation:javax.annotation-api')
+    testImplementation("junit:junit")
+    testImplementation('org.assertj:assertj-core')
 }
 
 protobuf {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,1 @@
-grpcVersion = 1.46.0
-protobufGradle = 0.8.18
-protobufVersion = 3.20.1
-protocVersion = 3.20.1
+protobufGradlePluginVersion= 0.8.18

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,4 @@
+grpcVersion = 1.46.0
+protobufGradle = 0.8.18
+protobufVersion = 3.20.1
+protocVersion = 3.20.1

--- a/grpc-utils/build.gradle
+++ b/grpc-utils/build.gradle
@@ -8,7 +8,7 @@ repositories {
 }
 
 dependencies {
-    api platform(project(":dependencies"))
+    implementation platform(project(":dependencies"))
     // command line parser
     implementation("commons-cli:commons-cli")
     // gRPC server

--- a/grpc-utils/build.gradle
+++ b/grpc-utils/build.gradle
@@ -8,7 +8,7 @@ repositories {
 }
 
 dependencies {
-    api platform(project(path: ":dependencies"))
+    api platform(project(":dependencies"))
     // command line parser
     implementation("commons-cli:commons-cli")
     // gRPC server

--- a/grpc-utils/build.gradle
+++ b/grpc-utils/build.gradle
@@ -1,5 +1,4 @@
 plugins {
-    id "java"
     id "java-library"
     id "idea"
 }
@@ -8,22 +7,19 @@ repositories {
     mavenCentral()
 }
 
-def grpcVersion = "1.46.0"
-
-
 dependencies {
+    api platform(project(path: ":dependencies"))
     // command line parser
-    implementation("commons-cli:commons-cli:1.5.0")
+    implementation("commons-cli:commons-cli")
     // gRPC server
-    api("io.grpc:grpc-protobuf:${grpcVersion}")
-    api("io.grpc:grpc-stub:${grpcVersion}")
-    api("io.grpc:grpc-services:${grpcVersion}")
-    api("io.grpc:grpc-api:${grpcVersion}")
-    api("io.grpc:grpc-netty-shaded:${grpcVersion}")
+    api("io.grpc:grpc-protobuf")
+    api("io.grpc:grpc-stub")
+    api("io.grpc:grpc-services")
+    api("io.grpc:grpc-api")
+    api("io.grpc:grpc-netty-shaded")
     // gRPC monitoring
-    implementation("me.dinowernli:java-grpc-prometheus:0.5.0")
-    implementation("io.prometheus:simpleclient_httpserver:0.15.0")
-    testImplementation("junit:junit:4.11")
-    testImplementation('org.assertj:assertj-core:3.21.0')
-
+    implementation("me.dinowernli:java-grpc-prometheus")
+    implementation("io.prometheus:simpleclient_httpserver")
+    testImplementation("junit:junit")
+    testImplementation('org.assertj:assertj-core')
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,4 @@
 rootProject.name = 'grpc-utils'
 include 'examples'
 include 'grpc-utils'
+include 'dependencies'

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,9 @@
+pluginManagement {
+    plugins {
+        id "com.google.protobuf" version "${protobufGradlePluginVersion}" apply false
+    }
+}
+
 rootProject.name = 'grpc-utils'
 include 'examples'
 include 'grpc-utils'


### PR DESCRIPTION
* new module for all dependencies
* new `build.gradle` at the root with the common version numbers (with `ext` to be used in other modules)
* new `gradle.properties` file for the version that cannot be centralized
* `pluginManagement` section in` settings.gradle`
* modified existing gradles files to exploit the modifications just mentioned above