### PR TITLE
Clean code

### DIFF
--- a/grpc-utils/src/main/java/com/glegoux/grpc/server/GrpcServer.java
+++ b/grpc-utils/src/main/java/com/glegoux/grpc/server/GrpcServer.java
@@ -3,7 +3,7 @@ package com.glegoux.grpc.server;
 import java.io.IOException;
 
 public interface GrpcServer {
-    void start()  throws IOException;
+    void start() throws IOException;
+
     void stop() throws InterruptedException;
-    void blockUntilShutdown() throws InterruptedException;
 }

--- a/grpc-utils/src/main/java/com/glegoux/grpc/server/GrpcServerSimple.java
+++ b/grpc-utils/src/main/java/com/glegoux/grpc/server/GrpcServerSimple.java
@@ -122,8 +122,4 @@ public class GrpcServerSimple implements GrpcServer {
         return numberOfThreads;
     }
 
-    public List<BindableService> getServices() {
-        return services;
-    }
-
 }

--- a/grpc-utils/src/main/java/com/glegoux/grpc/server/GrpcServerSimple.java
+++ b/grpc-utils/src/main/java/com/glegoux/grpc/server/GrpcServerSimple.java
@@ -33,12 +33,11 @@ public class GrpcServerSimple implements GrpcServer {
     private final int numberOfThreads;
     private final List<BindableService> services;
 
-
     public GrpcServerSimple(int port, int monitoringPort, int numberOfThreads, List<BindableService> services) {
         this.port = port;
         this.monitoringPort = monitoringPort;
-        this.services = services;
         this.numberOfThreads = numberOfThreads;
+        this.services = services;
     }
 
     @Override
@@ -46,9 +45,9 @@ public class GrpcServerSimple implements GrpcServer {
 
         MonitoringServerInterceptor monitoringInterceptor = MonitoringServerInterceptor.create(Configuration.allMetrics());
 
-        ThreadPoolExecutor healthServiceThreadPoolExecutor = GrpcThreadPoolHelper.newFixedThreadPool(1, "grpc-health-service");
+        ThreadPoolExecutor healthServiceThreadPoolExecutor = GrpcThreadPoolHelper.newFixedThreadPool(1, "health-service");
         ThreadPoolExecutor reflectionServiceThreadPoolExecutor = GrpcThreadPoolHelper.newFixedThreadPool(1, "reflection-service");
-        ThreadPoolExecutor servicesThreadPoolExecutor = GrpcThreadPoolHelper.newFixedThreadPool(this.numberOfThreads, "grpc-services");
+        ThreadPoolExecutor servicesThreadPoolExecutor = GrpcThreadPoolHelper.newFixedThreadPool(this.numberOfThreads, "services");
 
         NettyServerBuilder serverBuilder = NettyServerBuilder.forPort(this.port)
                 .callExecutor(new ServerCallExecutorSupplier() {
@@ -101,13 +100,6 @@ public class GrpcServerSimple implements GrpcServer {
         }
     }
 
-    @Override
-    public void blockUntilShutdown() throws InterruptedException {
-        if (this.server != null) {
-            this.server.awaitTermination();
-        }
-    }
-
     public static GrpcServerSimple run(String programName, String[] args, List<BindableService> services) throws IOException {
         GrpcServerSimpleArguments arguments = new GrpcServerSimpleArguments(programName, args);
         int port = arguments.getPort();
@@ -129,4 +121,9 @@ public class GrpcServerSimple implements GrpcServer {
     public int getNumberOfThreads() {
         return numberOfThreads;
     }
+
+    public List<BindableService> getServices() {
+        return services;
+    }
+
 }

--- a/grpc-utils/src/main/java/com/glegoux/grpc/server/GrpcThreadPoolHelper.java
+++ b/grpc-utils/src/main/java/com/glegoux/grpc/server/GrpcThreadPoolHelper.java
@@ -7,13 +7,13 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 public class GrpcThreadPoolHelper {
 
-    public static ThreadPoolExecutor newFixedThreadPool(int nThreads, String threadPoolName) {
-        ThreadPoolExecutor threadPool = (ThreadPoolExecutor) Executors.newFixedThreadPool(nThreads, new ThreadFactory() {
+    public static ThreadPoolExecutor newFixedThreadPool(int numberOfThreads, String threadPoolName) {
+        ThreadPoolExecutor threadPool = (ThreadPoolExecutor) Executors.newFixedThreadPool(numberOfThreads, new ThreadFactory() {
             final AtomicInteger counter = new AtomicInteger(0);
 
             @Override
             public Thread newThread(Runnable runnable) {
-                String threadName = String.format("grpc-fixed-threadpool-%s-%d_%d", threadPoolName, nThreads, counter.incrementAndGet());
+                String threadName = String.format("grpc-fixed-threadpool-%s-%d_%d", threadPoolName, numberOfThreads, counter.incrementAndGet());
                 Thread thread = new Thread(runnable, threadName);
                 thread.setDaemon(true);
                 return thread;


### PR DESCRIPTION
- Remove blockUntilShutdown() in GrpcServer from it is not used
- Rename thread pools in GrpcServerSimple without grpc already inside the name
- Add getter for services in GrpcServerSimple
- Use numberOfThreads instead of nThreads