### PR TITLE
Catch the right exceptions when an incorrect port given in the cli

### DIFF
--- a/grpc-utils/src/main/java/com/glegoux/grpc/server/GrpcServerSimpleArguments.java
+++ b/grpc-utils/src/main/java/com/glegoux/grpc/server/GrpcServerSimpleArguments.java
@@ -1,6 +1,5 @@
 package com.glegoux.grpc.server;
 
-
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
 import org.apache.commons.cli.DefaultParser;
@@ -16,7 +15,6 @@ public class GrpcServerSimpleArguments {
     static final int DEFAULT_PORT = 8000;
     static final int DEFAULT_MONITORING_PORT = 8001;
     static final int DEFAULT_NUMBER_OF_THREADS = Runtime.getRuntime().availableProcessors();
-
 
     private final String programName;
     private int port = DEFAULT_PORT;
@@ -97,16 +95,16 @@ public class GrpcServerSimpleArguments {
         Long port;
         try {
             port = (Long) cmd.getParsedOptionValue(longOpt);
-            if (port == null || !(1024 <= port && port <= 65535)) {
-                throw new ParseException(getExceptionMsg(cmd, longOpt));
-            }
-        } catch (ClassCastException e) {
-            throw new ParseException(getExceptionMsg(cmd, longOpt));
+        } catch (ParseException | ClassCastException e) {
+            throw new ParseException(getParseExceptionMsgForPort(cmd, longOpt));
+        }
+        if (port == null || !(1024 <= port && port <= 65535)) {
+            throw new ParseException(getParseExceptionMsgForPort(cmd, longOpt));
         }
         return port.intValue();
     }
 
-    private String getExceptionMsg(CommandLine cmd, String longOpt) {
+    private String getParseExceptionMsgForPort(CommandLine cmd, String longOpt) {
         return String.format(
             "Failed to get the value `%s` of the option --%s must be an integer between 1024 and 65535",
             cmd.getOptionValue(longOpt), longOpt);


### PR DESCRIPTION
If the port is a `Number` (float, double, ...) but not a `Long` then `ClassCastException` is raised.
If the port is not a `Number` then `ParseException` is raised, then the message is rewritten to be more explicit.

In addition, catch only the required block of code, and rename `getParseExceptionMsgForPort` to be more appropriate.